### PR TITLE
NZTB-3: added Command pattern for handling Telegram Bot commands

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,3 +4,7 @@
 
 * added stub telegram bot
 * added SpringBoot skeleton project
+
+## 0.2.0-SNAPSHOT
+
+* implemented Command pattern for handling Telegram Bot commands

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.github.NikolayZebnitskiy</groupId>
 	<artifactId>telegramBot</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<name>telegramBot</name>
 	<description>Telegram Bot</description>
 	<properties>

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/bot/NZTelegramBot.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/bot/NZTelegramBot.java
@@ -1,6 +1,9 @@
 package com.github.NikolayZebnitskiy.telegramBot.bot;
 
 
+import com.github.NikolayZebnitskiy.telegramBot.command.CommandContainer;
+import com.github.NikolayZebnitskiy.telegramBot.command.NoCommand;
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageServiceImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
@@ -8,14 +11,24 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
+import static com.github.NikolayZebnitskiy.telegramBot.command.CommandName.NO;
+
 @Component
 public class NZTelegramBot extends TelegramLongPollingBot {
+
+    public static String COMMAND_PREFIX = "/";
 
     @Value("${bot.username}")
     private String username;
 
     @Value("${bot.token}")
     private String token;
+
+    private final CommandContainer commandContainer;
+
+    public NZTelegramBot() {
+        this.commandContainer = new CommandContainer(new SendBotMessageServiceImpl(this));
+    }
 
     @Override
     public String getBotUsername() {
@@ -33,16 +46,11 @@ public class NZTelegramBot extends TelegramLongPollingBot {
 
         if (update.hasMessage() && update.getMessage().hasText()) {
             String message = update.getMessage().getText().trim();
-            String chatId = update.getMessage().getChatId().toString();
-
-            SendMessage sendMessage = new SendMessage();
-            sendMessage.setChatId(chatId);
-            sendMessage.setText(message);
-
-            try {
-                execute(sendMessage);
-            } catch (TelegramApiException e) {
-                e.printStackTrace();
+            if (message.startsWith(COMMAND_PREFIX)) {
+                String commandIdentifier = message.split(" ")[0].toLowerCase();
+                commandContainer.retrieveCommand(commandIdentifier).execute(update);
+            } else {
+                commandContainer.retrieveCommand(NO.getCommandName()).execute(update);
             }
         }
     }

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/Command.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/Command.java
@@ -1,0 +1,15 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Command interface for handling telegram-bot commands.
+ */
+public interface Command {
+    /**
+     * Main method, which is executing command logic.
+     *
+     * @param update provided {@link Update} object with all the needed data for command.
+     */
+    void execute(Update update);
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/CommandContainer.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/CommandContainer.java
@@ -1,0 +1,31 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageService;
+import com.google.common.collect.ImmutableMap;
+
+import static com.github.NikolayZebnitskiy.telegramBot.command.CommandName.*;
+
+/**
+ * Container of the {@link Command}s, which are using for handling telegram commands.
+ */
+public class CommandContainer {
+
+    private final ImmutableMap<String, Command> commandMap;
+    private final Command unknownCommand;
+
+    public CommandContainer(SendBotMessageService sendBotMessageService) {
+
+        commandMap = ImmutableMap.<String, Command>builder()
+                .put(START.getCommandName(), new StartCommand(sendBotMessageService))
+                .put(STOP.getCommandName(), new StopCommand(sendBotMessageService))
+                .put(HELP.getCommandName(), new HelpCommand(sendBotMessageService))
+                .put(NO.getCommandName(), new NoCommand(sendBotMessageService))
+                .build();
+
+        unknownCommand = new UnknownCommand(sendBotMessageService);
+    }
+
+    public Command retrieveCommand(String commandIdentifier) {
+        return commandMap.getOrDefault(commandIdentifier, unknownCommand);
+    }
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/CommandName.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/CommandName.java
@@ -1,0 +1,19 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+public enum CommandName {
+
+    START("/start"),
+    STOP("/stop"),
+    HELP("/help"),
+    NO("/no");
+
+    private final String commandName;
+
+    CommandName(String commandName) {
+        this.commandName = commandName;
+    }
+
+    public String getCommandName() {
+        return commandName;
+    }
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/HelpCommand.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/HelpCommand.java
@@ -1,0 +1,31 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import static com.github.NikolayZebnitskiy.telegramBot.command.CommandName.*;
+
+/**
+ * Help {@link Command}.
+ */
+public class HelpCommand implements Command{
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public static final String HELP_MESSAGE = String.format("✨<b>Дотупные команды</b>✨\n\n"
+
+                    + "<b>Начать\\закончить работу с ботом</b>\n"
+                    + "%s - начать работу со мной\n"
+                    + "%s - приостановить работу со мной\n\n"
+                    + "%s - получить помощь в работе со мной\n",
+            START.getCommandName(), STOP.getCommandName(), HELP.getCommandName());
+
+    public HelpCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(), HELP_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/NoCommand.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/NoCommand.java
@@ -1,0 +1,24 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * No {@link Command}.
+ */
+public class NoCommand implements Command{
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public static final String NO_MESSAGE = "Я поддерживаю команды, начинающиеся со слеша(/).\n"
+            + "Чтобы посмотреть список команд введите /help";
+
+    public NoCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(), NO_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/StartCommand.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/StartCommand.java
@@ -1,0 +1,24 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Start {@link Command}.
+ */
+
+public class StartCommand implements Command {
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public static final String START_MESSAGE = "Привет. Я Telegram Bot. Я еще маленький и только учусь.";
+
+    public StartCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(), START_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/StopCommand.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/StopCommand.java
@@ -1,0 +1,23 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Stop {@link Command}.
+ */
+public class StopCommand implements Command {
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public static final String STOP_MESSAGE = "Деактивировал все ваши подписки \uD83D\uDE1F.";
+
+    public StopCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(), STOP_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/UnknownCommand.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/command/UnknownCommand.java
@@ -1,0 +1,24 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageService;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Unknown {@link Command}.
+ */
+public class UnknownCommand implements Command{
+
+    public static final String UNKNOWN_MESSAGE = "Не понимаю вас \uD83D\uDE1F, напишите /help чтобы узнать что я понимаю.";
+
+    private final SendBotMessageService sendBotMessageService;
+
+    public UnknownCommand(SendBotMessageService sendBotMessageService) {
+        this.sendBotMessageService = sendBotMessageService;
+    }
+
+    @Override
+    public void execute(Update update) {
+        sendBotMessageService.sendMessage(update.getMessage().getChatId().toString(), UNKNOWN_MESSAGE);
+    }
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/service/SendBotMessageService.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/service/SendBotMessageService.java
@@ -1,0 +1,15 @@
+package com.github.NikolayZebnitskiy.telegramBot.service;
+
+/**
+ * Service for sending messages via telegram-bot.
+ */
+public interface SendBotMessageService {
+
+    /**
+     * Send message via telegram bot.
+     *
+     * @param chatId provided chatId in which messages would be sent.
+     * @param message provided message to be sent.
+     */
+    void sendMessage(String chatId, String message);
+}

--- a/src/main/java/com/github/NikolayZebnitskiy/telegramBot/service/SendBotMessageServiceImpl.java
+++ b/src/main/java/com/github/NikolayZebnitskiy/telegramBot/service/SendBotMessageServiceImpl.java
@@ -1,0 +1,36 @@
+package com.github.NikolayZebnitskiy.telegramBot.service;
+
+import com.github.NikolayZebnitskiy.telegramBot.bot.NZTelegramBot;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+/**
+ * Implementation of {@link SendBotMessageService} interface.
+ */
+@Service
+public class SendBotMessageServiceImpl implements SendBotMessageService{
+
+    private final NZTelegramBot telegramBot;
+
+    @Autowired
+    public SendBotMessageServiceImpl(NZTelegramBot telegramBot) {
+        this.telegramBot = telegramBot;
+    }
+
+    @Override
+    public void sendMessage(String chatId, String message) {
+
+        SendMessage sendMessage = new SendMessage();
+        sendMessage.setChatId(chatId);
+        sendMessage.enableHtml(true);
+        sendMessage.setText(message);
+
+        try {
+            telegramBot.execute(sendMessage);
+        } catch (TelegramApiException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/AbstractCommandTest.java
+++ b/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/AbstractCommandTest.java
@@ -1,0 +1,47 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import com.github.NikolayZebnitskiy.telegramBot.bot.NZTelegramBot;
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageService;
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+/**
+ * Abstract class for testing {@link Command}s.
+ */
+abstract class AbstractCommandTest {
+
+   protected NZTelegramBot nzTelegramBot = Mockito.mock(NZTelegramBot.class);
+   protected SendBotMessageService sendBotMessageService = new SendBotMessageServiceImpl(nzTelegramBot);
+
+   abstract String getCommandName();
+
+   abstract String getCommandMessage();
+
+   abstract Command getCommand();
+
+   @Test
+   public void shouldProperlyExecuteCommand() throws TelegramApiException {
+      //given
+      Long chatId = 123456789L;
+
+      Update update = new Update();
+      Message message = Mockito.mock(Message.class);
+      Mockito.when(message.getChatId()).thenReturn(chatId);
+      Mockito.when(message.getText()).thenReturn(getCommandName());
+      update.setMessage(message);
+
+      SendMessage sendMessage = new SendMessage();
+      sendMessage.setChatId(chatId.toString());
+      sendMessage.setText(getCommandMessage());
+      sendMessage.enableHtml(true);
+      //when
+      getCommand().execute(update);
+      //then
+      Mockito.verify(nzTelegramBot).execute(sendMessage);
+   }
+}

--- a/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/CommandContainerTest.java
+++ b/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/CommandContainerTest.java
@@ -1,0 +1,43 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+
+import com.github.NikolayZebnitskiy.telegramBot.service.SendBotMessageService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+
+@DisplayName("Unit-level testing for CommandContainer")
+public class CommandContainerTest {
+
+    private CommandContainer commandContainer;
+
+    @BeforeEach
+    public void init() {
+        SendBotMessageService sendBotMessageService = Mockito.mock(SendBotMessageService.class);
+        commandContainer = new CommandContainer(sendBotMessageService);
+    }
+
+    @Test
+    public void shouldGetAllTheExistingCommands() {
+        //when-then
+        Arrays.stream(CommandName.values())
+                .forEach(commandName -> {
+                    Command command = commandContainer.retrieveCommand(commandName.getCommandName());
+                    Assertions.assertNotEquals(UnknownCommand.class, command.getClass());
+                });
+    }
+
+    @Test
+    public void shouldReturnUnknownCommand() {
+        //given
+        String unknownCommand = "/fdfsres";
+        //when
+        Command command = commandContainer.retrieveCommand(unknownCommand);
+        //then
+        Assertions.assertEquals(UnknownCommand.class, command.getClass());
+    }
+}

--- a/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/HelpCommandTest.java
+++ b/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/HelpCommandTest.java
@@ -1,0 +1,25 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.NikolayZebnitskiy.telegramBot.command.CommandName.HELP;
+import static com.github.NikolayZebnitskiy.telegramBot.command.HelpCommand.HELP_MESSAGE;
+
+@DisplayName("Unit-level testing for HelpCommand")
+public class HelpCommandTest extends AbstractCommandTest{
+
+    @Override
+    String getCommandName() {
+        return HELP.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return HELP_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new HelpCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/NoCommandTest.java
+++ b/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/NoCommandTest.java
@@ -1,0 +1,25 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.NikolayZebnitskiy.telegramBot.command.CommandName.NO;
+import static com.github.NikolayZebnitskiy.telegramBot.command.NoCommand.NO_MESSAGE;
+
+@DisplayName("Unit-level testing for NoCommand")
+public class NoCommandTest extends AbstractCommandTest {
+
+    @Override
+    String getCommandName() {
+        return NO.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return NO_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new NoCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/StartCommandTest.java
+++ b/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/StartCommandTest.java
@@ -1,0 +1,25 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.NikolayZebnitskiy.telegramBot.command.CommandName.START;
+import static com.github.NikolayZebnitskiy.telegramBot.command.StartCommand.START_MESSAGE;
+
+@DisplayName("Unit-level testing for StartCommand")
+public class StartCommandTest extends AbstractCommandTest{
+
+    @Override
+    String getCommandName() {
+        return START.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return START_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new StartCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/StopCommandTest.java
+++ b/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/StopCommandTest.java
@@ -1,0 +1,25 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.NikolayZebnitskiy.telegramBot.command.CommandName.STOP;
+import static com.github.NikolayZebnitskiy.telegramBot.command.StopCommand.STOP_MESSAGE;
+
+@DisplayName("Unit-level testing for StopCommand")
+public class StopCommandTest extends AbstractCommandTest{
+
+    @Override
+    String getCommandName() {
+        return STOP.getCommandName();
+    }
+
+    @Override
+    String getCommandMessage() {
+        return STOP_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new StopCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/UnknownCommandTest.java
+++ b/src/test/java/com/github/NikolayZebnitskiy/telegramBot/command/UnknownCommandTest.java
@@ -1,0 +1,24 @@
+package com.github.NikolayZebnitskiy.telegramBot.command;
+
+import org.junit.jupiter.api.DisplayName;
+
+import static com.github.NikolayZebnitskiy.telegramBot.command.UnknownCommand.UNKNOWN_MESSAGE;
+
+@DisplayName("Unit-level testing for UnknownCommand")
+public class UnknownCommandTest extends AbstractCommandTest{
+
+    @Override
+    String getCommandName() {
+        return "/fdgdfgdfgdbd";
+    }
+
+    @Override
+    String getCommandMessage() {
+        return UNKNOWN_MESSAGE;
+    }
+
+    @Override
+    Command getCommand() {
+        return new UnknownCommand(sendBotMessageService);
+    }
+}

--- a/src/test/java/com/github/NikolayZebnitskiy/telegramBot/service/SendBotMessageServiceTest.java
+++ b/src/test/java/com/github/NikolayZebnitskiy/telegramBot/service/SendBotMessageServiceTest.java
@@ -1,0 +1,40 @@
+package com.github.NikolayZebnitskiy.telegramBot.service;
+
+import com.github.NikolayZebnitskiy.telegramBot.bot.NZTelegramBot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+@DisplayName("Unit-level testing for SendBotMessageService")
+public class SendBotMessageServiceTest {
+
+    private SendBotMessageService sendBotMessageService;
+    private NZTelegramBot nzTelegramBot;
+
+    @BeforeEach
+    public void init() {
+        nzTelegramBot = Mockito.mock(NZTelegramBot.class);
+        sendBotMessageService = new SendBotMessageServiceImpl(nzTelegramBot);
+    }
+
+    @Test
+    public void shouldProperlySendMessage() throws TelegramApiException {
+        //given
+        String chatId = "test_chat_id";
+        String message = "test_message";
+
+        SendMessage sendMessage = new SendMessage();
+        sendMessage.setText(message);
+        sendMessage.setChatId(chatId);
+        sendMessage.enableHtml(true);
+
+        //when
+        sendBotMessageService.sendMessage(chatId, message);
+
+        //then
+        Mockito.verify(nzTelegramBot).execute(sendMessage);
+    }
+}


### PR DESCRIPTION
PR Details

Implemented Command Pattern for handling Telegram bot commands.
Tests added, too.

New feature (non-breaking change which adds functionality)